### PR TITLE
refactor: extract ast utility functions

### DIFF
--- a/src/rules/no-jsx-non-null-assertion.ts
+++ b/src/rules/no-jsx-non-null-assertion.ts
@@ -1,5 +1,4 @@
-import isInsideJSX from "src/utils/ast/is-inside-jsx";
-
+import isInsideJSX from "../utils/ast/is-inside-jsx";
 import { createEslintRule, type RuleModule } from "../utils/create-rule";
 
 export const RULE_NAME = "no-jsx-non-null-assertion";

--- a/src/rules/no-jsx-non-null-assertion.ts
+++ b/src/rules/no-jsx-non-null-assertion.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from "@typescript-eslint/utils";
+import isInsideJSX from "src/utils/ast/is-inside-jsx";
 
 import { createEslintRule, type RuleModule } from "../utils/create-rule";
 
@@ -23,27 +23,9 @@ const rule: RuleModule<Options> = createEslintRule<Options, MessageIds>({
   },
   defaultOptions: [],
   create: (context) => {
-    function isInsideJSXExpression(node: TSESTree.Node): boolean {
-      let current = node.parent;
-      while (current) {
-        if (current.type === TSESTree.AST_NODE_TYPES.JSXExpressionContainer) {
-          return true;
-        }
-        if (current.type === TSESTree.AST_NODE_TYPES.JSXSpreadAttribute) {
-          return true;
-        }
-        if (current.type === TSESTree.AST_NODE_TYPES.JSXAttribute) {
-          return true;
-        }
-        current = current.parent;
-      }
-
-      return false;
-    }
-
     return {
       TSNonNullExpression(node) {
-        if (isInsideJSXExpression(node)) {
+        if (isInsideJSX(node)) {
           context.report({
             node,
             messageId: "noJsxNonNullAssertion",

--- a/src/rules/no-jsx-optional-chaining.ts
+++ b/src/rules/no-jsx-optional-chaining.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from "@typescript-eslint/utils";
+import isInsideJSX from "src/utils/ast/is-inside-jsx";
 
 import { createEslintRule, type RuleModule } from "../utils/create-rule";
 
@@ -23,27 +23,9 @@ const rule: RuleModule<Options> = createEslintRule<Options, MessageIds>({
   },
   defaultOptions: [],
   create: (context) => {
-    function isInsideJSXExpression(node: TSESTree.Node): boolean {
-      let current = node.parent;
-      while (current) {
-        if (current.type === TSESTree.AST_NODE_TYPES.JSXExpressionContainer) {
-          return true;
-        }
-        if (current.type === TSESTree.AST_NODE_TYPES.JSXSpreadAttribute) {
-          return true;
-        }
-        if (current.type === TSESTree.AST_NODE_TYPES.JSXAttribute) {
-          return true;
-        }
-        current = current.parent;
-      }
-
-      return false;
-    }
-
     return {
       ChainExpression(node) {
-        if (isInsideJSXExpression(node)) {
+        if (isInsideJSX(node)) {
           context.report({
             node,
             messageId: "noJsxOptionalChaining",

--- a/src/rules/no-jsx-optional-chaining.ts
+++ b/src/rules/no-jsx-optional-chaining.ts
@@ -1,5 +1,4 @@
-import isInsideJSX from "src/utils/ast/is-inside-jsx";
-
+import isInsideJSX from "../utils/ast/is-inside-jsx";
 import { createEslintRule, type RuleModule } from "../utils/create-rule";
 
 export const RULE_NAME = "no-jsx-optional-chaining";

--- a/src/rules/no-unsafe-type-assertion.ts
+++ b/src/rules/no-unsafe-type-assertion.ts
@@ -1,6 +1,6 @@
 import { TSESTree } from "@typescript-eslint/utils";
-import hasCommentAbove from "src/utils/ast/has-comment-above";
 
+import hasCommentAbove from "../utils/ast/has-comment-above";
 import { createEslintRule, type RuleModule } from "../utils/create-rule";
 
 export const RULE_NAME = "no-unsafe-type-assertion";

--- a/src/utils/ast/has-comment-above.ts
+++ b/src/utils/ast/has-comment-above.ts
@@ -1,0 +1,38 @@
+import type { RuleContext } from "@typescript-eslint/utils/ts-eslint";
+
+import { TSESTree } from "@typescript-eslint/utils";
+
+export default function hasCommentAbove<
+  MessageIds extends string,
+  Options extends readonly unknown[],
+>(node: TSESTree.Node, context: RuleContext<MessageIds, Options>): boolean {
+  const { sourceCode } = context;
+
+  const comments = sourceCode.getAllComments();
+
+  // Check for comments in the lines immediately before the node
+  return comments.some((comment) => {
+    const commentLine = sourceCode.getLocFromIndex(comment.range[0]).line;
+    const commentEndLine = sourceCode.getLocFromIndex(comment.range[1]).line;
+
+    const nextToken = sourceCode.getTokenAfter(comment, {
+      includeComments: true,
+    });
+
+    if (!nextToken) return false;
+
+    const nextTokenLine = sourceCode.getLocFromIndex(nextToken.range[0]).line;
+
+    // For multi-line comments, use the end line instead of the start line
+    const effectiveCommentLine =
+      comment.type === TSESTree.AST_TOKEN_TYPES.Block
+        ? commentEndLine
+        : commentLine;
+
+    return (
+      comment.value.trim().length > 0 &&
+      nextTokenLine === effectiveCommentLine + 1 &&
+      nextToken.range[0] <= node.range[0]
+    );
+  });
+}

--- a/src/utils/ast/is-inside-jsx.ts
+++ b/src/utils/ast/is-inside-jsx.ts
@@ -1,0 +1,19 @@
+import { TSESTree } from "@typescript-eslint/utils";
+
+export default function isInsideJSX(node: TSESTree.Node): boolean {
+  let current = node.parent;
+  while (current) {
+    if (current.type === TSESTree.AST_NODE_TYPES.JSXExpressionContainer) {
+      return true;
+    }
+    if (current.type === TSESTree.AST_NODE_TYPES.JSXSpreadAttribute) {
+      return true;
+    }
+    if (current.type === TSESTree.AST_NODE_TYPES.JSXAttribute) {
+      return true;
+    }
+    current = current.parent;
+  }
+
+  return false;
+}


### PR DESCRIPTION
This pull request refactors the codebase by extracting common utility functions and updating rule implementations to use these utilities. The primary changes involve moving the `isInsideJSX` and `hasCommentAbove` functions to separate utility files and updating the rules to use these new utility functions.

### Refactoring for Code Reusability:

* Extracted the `isInsideJSX` function to `src/utils/ast/is-inside-jsx.ts` and updated `src/rules/no-jsx-non-null-assertion.ts` and `src/rules/no-jsx-optional-chaining.ts` to use this utility function. [[1]](diffhunk://#diff-ffbc0c90226d892dffbdf16781978eab9d60e9c723e4aa61cf7c41c05dd8b26bL1-R1) [[2]](diffhunk://#diff-ffbc0c90226d892dffbdf16781978eab9d60e9c723e4aa61cf7c41c05dd8b26bL26-R28) [[3]](diffhunk://#diff-f3e6b663fcc21fbe7948797d15d77f7e7616b9435184900abc15b60f90fc930aL1-R1) [[4]](diffhunk://#diff-f3e6b663fcc21fbe7948797d15d77f7e7616b9435184900abc15b60f90fc930aL26-R28) [[5]](diffhunk://#diff-6da100112f3fc04b554742e7fa23d6dbce3f861f4e1275f8a8c6e413caebbdfcR1-R19)
* Extracted the `hasCommentAbove` function to `src/utils/ast/has-comment-above.ts` and updated `src/rules/no-unsafe-type-assertion.ts` to use this utility function. [[1]](diffhunk://#diff-2107618edacf3ec162f491ec9fc8c858c0e3e833a2e5e6b344dbbec0c4cfd7c0R2) [[2]](diffhunk://#diff-2107618edacf3ec162f491ec9fc8c858c0e3e833a2e5e6b344dbbec0c4cfd7c0L28-R29) [[3]](diffhunk://#diff-2107618edacf3ec162f491ec9fc8c858c0e3e833a2e5e6b344dbbec0c4cfd7c0L42-R45) [[4]](diffhunk://#diff-038cfe4a75f562527d14782a7c31064d0e478e32e7bb660006d7654310676f9fR1-R38)

These changes improve code maintainability by reducing duplication and centralizing common logic in utility functions.