### PR TITLE
fix(`prefer-one-line-arrow-function`): handle object literal in fix

### DIFF
--- a/src/rules/prefer-one-line-arrow-function.test.ts
+++ b/src/rules/prefer-one-line-arrow-function.test.ts
@@ -20,10 +20,7 @@ const invalids = [
     "const fn = async (a: number, b: string): Promise<number> => { return 42 }",
     "const fn = async (a: number, b: string): Promise<number> => 42",
   ],
-  [
-    "const fn = () => { return { num: 42 } }",
-    "const fn = () => ({ num: 42 })",
-  ],
+  ["const fn = () => { return { num: 42 } }", "const fn = () => ({ num: 42 })"],
 ];
 
 runTest({

--- a/src/rules/prefer-one-line-arrow-function.test.ts
+++ b/src/rules/prefer-one-line-arrow-function.test.ts
@@ -20,6 +20,10 @@ const invalids = [
     "const fn = async (a: number, b: string): Promise<number> => { return 42 }",
     "const fn = async (a: number, b: string): Promise<number> => 42",
   ],
+  [
+    "const fn = () => { return { num: 42 } }",
+    "const fn = () => ({ num: 42 })",
+  ],
 ];
 
 runTest({

--- a/src/rules/prefer-one-line-arrow-function.test.ts
+++ b/src/rules/prefer-one-line-arrow-function.test.ts
@@ -21,6 +21,10 @@ const invalids = [
     "const fn = async (a: number, b: string): Promise<number> => 42",
   ],
   ["const fn = () => { return { num: 42 } }", "const fn = () => ({ num: 42 })"],
+  [
+    "const fn = () => { return { num: 42 } satisfies { num: number } }",
+    "const fn = () => ({ num: 42 } satisfies { num: number })",
+  ],
 ];
 
 runTest({

--- a/src/rules/prefer-one-line-arrow-function.ts
+++ b/src/rules/prefer-one-line-arrow-function.ts
@@ -46,10 +46,14 @@ const rule: RuleModule<Options> = createEslintRule<Options, MessageIds>({
           returnStatement.argument,
         );
 
-        // If an object literal is returned, wrap it in parentheses
+        // Wrap the returning object literal in parentheses, including when it's part of a satisfies expression
         const needsParens =
           returnStatement.argument.type ===
-          TSESTree.AST_NODE_TYPES.ObjectExpression;
+            TSESTree.AST_NODE_TYPES.ObjectExpression ||
+          (returnStatement.argument.type ===
+            TSESTree.AST_NODE_TYPES.TSSatisfiesExpression &&
+            returnStatement.argument.expression.type ===
+              TSESTree.AST_NODE_TYPES.ObjectExpression);
 
         const returnText = needsParens ? `(${returnArgText})` : returnArgText;
 

--- a/src/rules/prefer-one-line-arrow-function.ts
+++ b/src/rules/prefer-one-line-arrow-function.ts
@@ -46,7 +46,7 @@ const rule: RuleModule<Options> = createEslintRule<Options, MessageIds>({
           returnStatement.argument,
         );
 
-        // Wrap the returning object literal in parentheses, including when it's part of a satisfies expression
+        // If an object literal is returned, wrap it in parentheses
         const needsParens =
           returnStatement.argument.type ===
             TSESTree.AST_NODE_TYPES.ObjectExpression ||

--- a/src/rules/prefer-one-line-arrow-function.ts
+++ b/src/rules/prefer-one-line-arrow-function.ts
@@ -41,6 +41,17 @@ const rule: RuleModule<Options> = createEslintRule<Options, MessageIds>({
         const returnStatement = body[0];
         if (!returnStatement.argument) return;
 
+        // Get the return argument text
+        const returnArgText = context.sourceCode.getText(
+          returnStatement.argument,
+        );
+
+        // If an object literal is returned, wrap it in parentheses
+        const needsParens =
+          returnStatement.argument.type ===
+          TSESTree.AST_NODE_TYPES.ObjectExpression;
+        const returnText = needsParens ? `(${returnArgText})` : returnArgText;
+
         // Get type annotations for function parameters and return value
         const typeParameters = node.typeParameters
           ? context.sourceCode.getText(node.typeParameters)
@@ -58,7 +69,7 @@ const rule: RuleModule<Options> = createEslintRule<Options, MessageIds>({
           );
 
         // Construct new arrow function expression
-        const newArrowFunction = `${node.async ? "async " : ""}${typeParameters}(${params})${returnType} => ${context.sourceCode.getText(returnStatement.argument)}`;
+        const newArrowFunction = `${node.async ? "async " : ""}${typeParameters}(${params})${returnType} => ${returnText}`;
 
         context.report({
           node,

--- a/src/rules/prefer-one-line-arrow-function.ts
+++ b/src/rules/prefer-one-line-arrow-function.ts
@@ -50,6 +50,7 @@ const rule: RuleModule<Options> = createEslintRule<Options, MessageIds>({
         const needsParens =
           returnStatement.argument.type ===
           TSESTree.AST_NODE_TYPES.ObjectExpression;
+
         const returnText = needsParens ? `(${returnArgText})` : returnArgText;
 
         // Get type annotations for function parameters and return value


### PR DESCRIPTION
This pull request includes improvements to the `prefer-one-line-arrow-function` rule in the ESLint configuration. The changes enhance the handling of object literals returned by arrow functions and add new test cases to ensure the rule works correctly.

Enhancements to `prefer-one-line-arrow-function` rule:

* [`src/rules/prefer-one-line-arrow-function.ts`](diffhunk://#diff-9da2871729cf25a416bd50edd7a78ce00ee10da1a407905d107524d5bae76d38R44-R54): Added logic to wrap object literals in parentheses when returned by arrow functions. This ensures that the transformed code is syntactically correct. [[1]](diffhunk://#diff-9da2871729cf25a416bd50edd7a78ce00ee10da1a407905d107524d5bae76d38R44-R54) [[2]](diffhunk://#diff-9da2871729cf25a416bd50edd7a78ce00ee10da1a407905d107524d5bae76d38L61-R72)

Addition of new test cases:

* [`src/rules/prefer-one-line-arrow-function.test.ts`](diffhunk://#diff-4b255404a8facf51508332ac43a70443ff0300e6e0a5429bf6d4eeef5e04cd97R23-R26): Added new test cases to the `invalids` array to cover scenarios where object literals are returned by arrow functions.