### PR TITLE
chore(`function-params-destructuring`): simplify auto fix behavior

### DIFF
--- a/src/rules/function-params-destructuring.md
+++ b/src/rules/function-params-destructuring.md
@@ -17,12 +17,10 @@ This rule enforces a coding style where object parameters are not destructured i
 
 ### Parameter Naming Convention
 
-When applying auto-fix, the rule follows these priorities for the parameter name:
+When applying auto-fix:
 
 1. If the function returns JSX (React components), the parameter will be named `props`
-2. If the type ends with `Props` (including intersection types like `ButtonProps & HTMLProps`), the parameter will also be named `props`
-3. For other types, the parameter will be named as camelCase of the type name (e.g., `Person` -> `person`)
-4. If type cannot be inferred, fallback to `params`
+2. Otherwise, the parameter will be named `params`
 
 ### ❌ Incorrect
 

--- a/src/rules/function-params-destructuring.test.ts
+++ b/src/rules/function-params-destructuring.test.ts
@@ -44,20 +44,20 @@ runTest({
     {
       code: "function foo({ name, age, email }: Person) { console.log(name) }",
       output:
-        "function foo(person: Person) {\n  const { name, age, email } = person\n  console.log(name)\n}",
+        "function foo(params: Person) {\n  const { name, age, email } = params\n  console.log(name)\n}",
       errors: [{ messageId: "noParamDestructuring" }],
     },
     {
       code: "const foo = ({ id, value, type, name }: Item) => value",
       output:
-        "const foo = (item: Item) => {\n  const { id, value, type, name } = item\n  return value\n}",
+        "const foo = (params: Item) => {\n  const { id, value, type, name } = params\n  return value\n}",
       errors: [{ messageId: "noParamDestructuring" }],
     },
     // Exceeds custom maxDestructuredProperties
     {
       code: "function process({ a, b, c, d }: Props) { return a + b }",
       output:
-        "function process(props: Props) {\n  const { a, b, c, d } = props\n  return a + b\n}",
+        "function process(params: Props) {\n  const { a, b, c, d } = params\n  return a + b\n}",
       options: [{ maxDestructuredProperties: 3 }],
       errors: [{ messageId: "noParamDestructuring" }],
     },
@@ -65,16 +65,18 @@ runTest({
     {
       code: "function process({ x, y, ...rest }: Props) { return x + y }",
       output:
-        "function process(props: Props) {\n  const { x, y, ...rest } = props\n  return x + y\n}",
+        "function process(params: Props) {\n  const { x, y, ...rest } = params\n  return x + y\n}",
       errors: [{ messageId: "noParamDestructuring" }],
     },
-    // JSX return without Props suffix
+    // JSX return
+    // Expression return
     {
       code: "const Card = ({ title, description, image }: CardType) => <div>{title}</div>",
       output:
         "const Card = (props: CardType) => {\n  const { title, description, image } = props\n  return <div>{title}</div>\n}",
       errors: [{ messageId: "noParamDestructuring" }],
     },
+    // Block return
     {
       code: $`
         const Component = ({ 
@@ -91,19 +93,6 @@ runTest({
           return <div>{name}</div>
         }
       `,
-      errors: [{ messageId: "noParamDestructuring" }],
-    },
-    // Test cases for Props naming convention
-    {
-      code: "function Button({ onClick, className, disabled }: ButtonProps) { return <button onClick={onClick} /> }",
-      output:
-        "function Button(props: ButtonProps) {\n  const { onClick, className, disabled } = props\n  return <button onClick={onClick} />\n}",
-      errors: [{ messageId: "noParamDestructuring" }],
-    },
-    {
-      code: "const Input = ({ value, onChange, placeholder }: InputProps) => <input value={value} onChange={onChange} />",
-      output:
-        "const Input = (props: InputProps) => {\n  const { value, onChange, placeholder } = props\n  return <input value={value} onChange={onChange} />\n}",
       errors: [{ messageId: "noParamDestructuring" }],
     },
   ],

--- a/src/rules/function-params-destructuring.ts
+++ b/src/rules/function-params-destructuring.ts
@@ -1,5 +1,4 @@
 import { TSESTree } from "@typescript-eslint/utils";
-import { camelCase } from "es-toolkit";
 
 import { createEslintRule, type RuleModule } from "../utils/create-rule";
 
@@ -65,18 +64,6 @@ const rule: RuleModule<Options> = createEslintRule<Options, MessageIds>({
       return `const { ${properties} } = ${paramName}`;
     }
 
-    function hasPropsType(type: TSESTree.TypeNode): boolean {
-      if (type.type === TSESTree.AST_NODE_TYPES.TSTypeReference) {
-        const { typeName } = type;
-        if (typeName.type === TSESTree.AST_NODE_TYPES.Identifier)
-          return typeName.name.endsWith("Props");
-      } else if (type.type === TSESTree.AST_NODE_TYPES.TSIntersectionType) {
-        return type.types.some((t) => hasPropsType(t));
-      }
-
-      return false;
-    }
-
     function returnsJSX(
       node:
         | TSESTree.FunctionDeclaration
@@ -91,23 +78,24 @@ const rule: RuleModule<Options> = createEslintRule<Options, MessageIds>({
         return true;
       }
 
-      // Check return type annotation if it exists
-      if (node.returnType?.typeAnnotation) {
-        const returnType = node.returnType.typeAnnotation;
-
-        // Check if return type is JSX.Element or React.ReactNode or similar
-        if (returnType.type === TSESTree.AST_NODE_TYPES.TSTypeReference) {
-          const { typeName } = returnType;
-          if (typeName.type === TSESTree.AST_NODE_TYPES.Identifier) {
-            const { name } = typeName;
+      // Check function body for JSX returns
+      if (node.body.type === TSESTree.AST_NODE_TYPES.BlockStatement) {
+        const containsJSXReturn = node.body.body.some((statement) => {
+          if (statement.type === TSESTree.AST_NODE_TYPES.ReturnStatement) {
+            const { argument } = statement;
 
             return (
-              name === "JSX.Element" ||
-              name === "ReactElement" ||
-              name.includes("JSX") ||
-              name.includes("React")
+              argument &&
+              (argument.type === TSESTree.AST_NODE_TYPES.JSXElement ||
+                argument.type === TSESTree.AST_NODE_TYPES.JSXFragment)
             );
           }
+
+          return false;
+        });
+
+        if (containsJSXReturn) {
+          return true;
         }
       }
 
@@ -115,7 +103,6 @@ const rule: RuleModule<Options> = createEslintRule<Options, MessageIds>({
     }
 
     function suggestParamName(
-      param: TSESTree.ObjectPattern,
       node:
         | TSESTree.FunctionDeclaration
         | TSESTree.FunctionExpression
@@ -124,24 +111,7 @@ const rule: RuleModule<Options> = createEslintRule<Options, MessageIds>({
       // If function returns JSX, use 'props'
       if (returnsJSX(node)) return "props";
 
-      // Try to infer a good parameter name from the type annotation
-      if (param.typeAnnotation?.typeAnnotation) {
-        const typeNode = param.typeAnnotation.typeAnnotation;
-        // If any part of the type ends with Props, use 'props'
-        if (hasPropsType(typeNode)) return "props";
-
-        // For simple type reference, convert to camelCase
-        if (
-          typeNode.type === TSESTree.AST_NODE_TYPES.TSTypeReference &&
-          typeNode.typeName.type === TSESTree.AST_NODE_TYPES.Identifier
-        ) {
-          const { name } = typeNode.typeName;
-
-          return camelCase(name);
-        }
-      }
-
-      // Fallback to 'params'
+      // Otherwise, use 'params'
       return "params";
     }
 
@@ -162,7 +132,7 @@ const rule: RuleModule<Options> = createEslintRule<Options, MessageIds>({
               continue;
             }
 
-            const paramName = suggestParamName(param, node);
+            const paramName = suggestParamName(node);
             const typeAnnotation = getTypeAnnotation(param);
             const destructuring = generateDestructuring(param, paramName);
 


### PR DESCRIPTION
This pull request includes changes to simplify the parameter naming convention and improve the handling of JSX returns in the `function-params-destructuring` rule. The most important changes include modifying the parameter naming convention, updating the test cases, and removing unnecessary code.

Parameter Naming Convention:

* [`src/rules/function-params-destructuring.md`](diffhunk://#diff-ed788e832ed37837360125e0d198942d5fcf07888022ba6fbaf4e151b673c85cL20-R23): Simplified the parameter naming convention to always use `params` unless the function returns JSX, in which case the parameter will be named `props`.

Updates to Test Cases:

* [`src/rules/function-params-destructuring.test.ts`](diffhunk://#diff-a6287633afb86b2a142d69475114d4df9103ab527bd58cb71ee4cfcbb0e6ae1cL47-R79): Updated test cases to reflect the simplified parameter naming convention, removing cases for type-based naming. [[1]](diffhunk://#diff-a6287633afb86b2a142d69475114d4df9103ab527bd58cb71ee4cfcbb0e6ae1cL47-R79) [[2]](diffhunk://#diff-a6287633afb86b2a142d69475114d4df9103ab527bd58cb71ee4cfcbb0e6ae1cL96-L108)

Code Simplification:

* [`src/rules/function-params-destructuring.ts`](diffhunk://#diff-4a3fdfc161ff53392f833428e9ffb9d979006c9d9e0a07b3b493b5d5a31309e7L68-L79): Removed the `hasPropsType` function and related logic, as well as the logic for inferring parameter names from type annotations. Simplified the `returnsJSX` function to check the function body for JSX returns. [[1]](diffhunk://#diff-4a3fdfc161ff53392f833428e9ffb9d979006c9d9e0a07b3b493b5d5a31309e7L68-L79) [[2]](diffhunk://#diff-4a3fdfc161ff53392f833428e9ffb9d979006c9d9e0a07b3b493b5d5a31309e7L94-L118) [[3]](diffhunk://#diff-4a3fdfc161ff53392f833428e9ffb9d979006c9d9e0a07b3b493b5d5a31309e7L127-R114) [[4]](diffhunk://#diff-4a3fdfc161ff53392f833428e9ffb9d979006c9d9e0a07b3b493b5d5a31309e7L165-R135)
* [`src/rules/function-params-destructuring.ts`](diffhunk://#diff-4a3fdfc161ff53392f833428e9ffb9d979006c9d9e0a07b3b493b5d5a31309e7L2): Removed the import of `camelCase` from `es-toolkit` as it is no longer needed.