### PR TITLE
refactor(has-comment-above): simplify function declaration

### DIFF
--- a/src/rules/no-object-literal-type-assertion.ts
+++ b/src/rules/no-object-literal-type-assertion.ts
@@ -33,7 +33,7 @@ const rule: RuleModule<Options> = createEslintRule<Options, MessageIds>({
       TSAsExpression(node) {
         if (
           isObjectLiteral(node.expression) &&
-          !hasCommentAbove(node, context)
+          !hasCommentAbove(node, context.sourceCode)
         ) {
           context.report({
             node,

--- a/src/rules/no-unsafe-type-assertion.ts
+++ b/src/rules/no-unsafe-type-assertion.ts
@@ -42,7 +42,10 @@ const rule: RuleModule<Options> = createEslintRule<Options, MessageIds>({
 
     return {
       TSAsExpression(node) {
-        if (isUnsafeAssertion(node) && !hasCommentAbove(node, context)) {
+        if (
+          isUnsafeAssertion(node) &&
+          !hasCommentAbove(node, context.sourceCode)
+        ) {
           context.report({
             node,
             messageId: "noUnsafeTypeAssertion",

--- a/src/utils/ast/has-comment-above.ts
+++ b/src/utils/ast/has-comment-above.ts
@@ -1,13 +1,11 @@
-import type { RuleContext } from "@typescript-eslint/utils/ts-eslint";
+import type { SourceCode } from "@typescript-eslint/utils/ts-eslint";
 
 import { TSESTree } from "@typescript-eslint/utils";
 
-export default function hasCommentAbove<
-  MessageIds extends string,
-  Options extends readonly unknown[],
->(node: TSESTree.Node, context: RuleContext<MessageIds, Options>): boolean {
-  const { sourceCode } = context;
-
+export default function hasCommentAbove(
+  node: TSESTree.Node,
+  sourceCode: SourceCode,
+): boolean {
   const comments = sourceCode.getAllComments();
 
   // Check for comments in the lines immediately before the node


### PR DESCRIPTION
This pull request includes updates to how comments are checked above nodes in TypeScript ESLint rules. The changes involve modifying the `hasCommentAbove` function and updating its usage in two rule files.

### Updates to comment checking:

* [`src/utils/ast/has-comment-above.ts`](diffhunk://#diff-038cfe4a75f562527d14782a7c31064d0e478e32e7bb660006d7654310676f9fL1-R8): Refactored the `hasCommentAbove` function to directly accept `sourceCode` as a parameter instead of extracting it from the `context`.

### Rule adjustments:

* [`src/rules/no-object-literal-type-assertion.ts`](diffhunk://#diff-88de1e6846384b4bb191b44187d1c835a40f3b1d09ec0a5606640cec027db9bfL36-R36): Updated the `TSAsExpression` function to pass `context.sourceCode` to the `hasCommentAbove` function.
* [`src/rules/no-unsafe-type-assertion.ts`](diffhunk://#diff-2107618edacf3ec162f491ec9fc8c858c0e3e833a2e5e6b344dbbec0c4cfd7c0L45-R48): Modified the `TSAsExpression` function to pass `context.sourceCode` to the `hasCommentAbove` function and reformatted the condition for better readability.